### PR TITLE
Fix for Harder Difficulty in Reinstate

### DIFF
--- a/script/land_encounters/models/Zone.lua
+++ b/script/land_encounters/models/Zone.lua
@@ -183,6 +183,8 @@ function Zone:reinstate(previous_state, battle_event_factory)
                     self.battle_spots_mid = self.battle_spots_mid + 1
                 elseif self.spots[i].event.dilemma.difficulty_level == 3 then
                     self.battle_spots_hard = self.battle_spots_hard + 1
+                elseif self.spots[i].event.dilemma.difficulty_level == 4 then
+                    self.battle_spots_harder = self.battle_spots_harder + 1
                 end
                 
                 if self.spots[i].is_triggered then


### PR DESCRIPTION
I just added clauses for difficulty_level==4 to the reinstate function in Zone.lua since they were missing.

I'm not positive, but hopefully this will resolve the issue where too many events were popping up with the hardest difficulty